### PR TITLE
NEO-M9NのUBX-RXM-SFRBXメッセージが正常にデコードされるよう修正

### DIFF
--- a/azarashi/qzss_dcr_lib/decoder/ublox_qzss_dcr_decoder.py
+++ b/azarashi/qzss_dcr_lib/decoder/ublox_qzss_dcr_decoder.py
@@ -59,7 +59,7 @@ class UBloxQzssDcrDecoder(QzssDcrDecoderBase):
 
         # checks the data size
         num_data_word = self.sentence[10]
-        if num_data_word != 9:
+        if num_data_word * 4 + 8 != len(self.sentence) -(len(ublox_qzss_dcr_message_header) + 2 + 2): # SFRBX + Length + CHK
             raise QzssDcrDecoderException(
                 f'Invalid Message Length: {num_data_word}',
                 self)

--- a/azarashi/qzss_dcr_lib/decoder/ublox_qzss_dcr_decoder.py
+++ b/azarashi/qzss_dcr_lib/decoder/ublox_qzss_dcr_decoder.py
@@ -9,14 +9,14 @@ class UBloxQzssDcrDecoder(QzssDcrDecoderBase):
     schema = QzssDcReportBase
 
     def decode(self):
-        if len(self.sentence) < 52:
-            raise QzssDcrDecoderException(
-                'Too Short Sentence',
-                self)
-        if len(self.sentence) > 52:
-            raise QzssDcrDecoderException(
-                'Too Long Sentence',
-                self)
+#         if len(self.sentence) < 52:
+#             raise QzssDcrDecoderException(
+#                 'Too Short Sentence',
+#                 self)
+#         if len(self.sentence) > 52:
+#             raise QzssDcrDecoderException(
+#                 'Too Long Sentence',
+#                 self)
 
         # extracts a message header, satellite id, and message
         self.message_header = self.sentence[:len(ublox_qzss_dcr_message_header)]

--- a/azarashi/qzss_dcr_lib/definition/ublox_qzss_dcr_message_header.py
+++ b/azarashi/qzss_dcr_lib/definition/ublox_qzss_dcr_message_header.py
@@ -1,7 +1,5 @@
-ublox_qzss_dcr_message_header: bytes = b'\xB5\x62\x02\x13\x2C\x00\x05'
+ublox_qzss_dcr_message_header: bytes = b'\xB5\x62\x02\x13'
 # \xB5     -> ubx frame preamble sync char1
 # \x62     -> ubx frame preamble sync char2
 # \x02     -> message class: rbx
 # \x13     -> message id: sfrbx
-# \x2c\x00 -> payload length: 44 (little-endian 16-bit integer)
-# \x05     -> gnss id: qzss

--- a/azarashi/qzss_dcr_lib/interface/ublox_interface.py
+++ b/azarashi/qzss_dcr_lib/interface/ublox_interface.py
@@ -49,6 +49,9 @@ def ublox_qzss_dcr_message_extractor(reader, reader_args=(), reader_kwargs={}):
                             reader,
                             reader_args,
                             reader_kwargs)
+            
+            if message[6] != 5:  # gnssID != QZSS
+                continue
 
             if message[8] != 1:  # not a L1S signal
                 continue

--- a/azarashi/qzss_dcr_lib/interface/ublox_interface.py
+++ b/azarashi/qzss_dcr_lib/interface/ublox_interface.py
@@ -32,10 +32,20 @@ def ublox_qzss_dcr_message_extractor(reader, reader_args=(), reader_kwargs={}):
         else:
             match_count = 0
 
-        if match_count == len(ublox_qzss_dcr_message_header):
+        if match_count == len(ublox_qzss_dcr_message_header):  # SFRBX message
             match_count = 0
+            
+            message_length_lsb = __pop(1,reader,reader_args,reader_kwargs)[0]
+            
+            message_length_msb = __pop(1,reader,reader_args,reader_kwargs)[0]
+            
+            message_length = message_length_lsb + \
+                             (message_length_msb << 8)  # (little-endian 16-bit integer)
+            
             message = ublox_qzss_dcr_message_header + \
-                      __pop(52 - len(ublox_qzss_dcr_message_header),
+                      message_length_lsb.to_bytes(1,'little') + \
+                      message_length_msb.to_bytes(1,'little') + \
+                      __pop(message_length + 2 , # Payload + CK_A + CK_B
                             reader,
                             reader_args,
                             reader_kwargs)


### PR DESCRIPTION
#15 の問題を修正しました。
UBX-RXM-SFRBXメッセージ先頭のB5 62 02 13 を検出してから、次の2 Byte (ペイロード長)を特定して、ペイロード長 N Byte+チェックサム 2 Byte だけ読み込むよう修正しています。
また、UBX-RXM-SFRBXメッセージの長さが52 Byteとは限らないことから、その検査を廃止しました。
なお、本変更後に、NEO-M9NとMAX-M10Sで動作を確認しています。