### PR TITLE
UBX-RXM-SFRBXから変換された$QZQSMのSatIDが仕様内になるよう修正

### DIFF
--- a/azarashi/qzss_dcr_lib/decoder/qzss_dcr_decoder_base.py
+++ b/azarashi/qzss_dcr_lib/decoder/qzss_dcr_decoder_base.py
@@ -14,7 +14,7 @@ class QzssDcrDecoderBase:
     def message_to_nmea(self):
         sat_id = getattr(self, 'satellite_id', None)
         if sat_id is None:
-            sat_id = 55  # Set the satellite_id of PRN183 if it was default.
+            sat_id = 56  # Set the satellite_id of PRN184 if it was default.
 
         nmea_partial = '{header},{satellite_id},{message}'.format(header=nmea_qzss_dcr_message_header,
                                                                   satellite_id=sat_id,

--- a/azarashi/qzss_dcr_lib/decoder/ublox_qzss_dcr_decoder.py
+++ b/azarashi/qzss_dcr_lib/decoder/ublox_qzss_dcr_decoder.py
@@ -1,6 +1,7 @@
 from ..decoder import QzssDcrDecoder
 from ..decoder import QzssDcrDecoderBase
 from ..definition import ublox_qzss_dcr_message_header
+from ..definition import ublox_qzss_svn_prn_map
 from ..exception import QzssDcrDecoderException
 from ..report import QzssDcReportBase
 
@@ -47,8 +48,13 @@ class UBloxQzssDcrDecoder(QzssDcrDecoderBase):
                 self)
 
         # extracts a satellite id
-        self.satellite_id = self.sentence[7] + 51
-        self.satellite_prn = self.satellite_id | 0x80
+        self.satellite_prn = ublox_qzss_svn_prn_map.get(self.sentence[7])
+        if self.satellite_prn is None:
+            self.satellite_id = None
+        else:
+            # 2. PRNの下位6ビットからSatellite IDを計算
+            # 0x3F は二進数で 00111111 となり、これとのAND演算で下位6ビットのみが残る
+            self.satellite_id = self.satellite_prn & 0x3F
 
         # checks the signal id
         sig_id = self.sentence[8]

--- a/azarashi/qzss_dcr_lib/definition/__init__.py
+++ b/azarashi/qzss_dcr_lib/definition/__init__.py
@@ -53,3 +53,4 @@ from .qzss_dcx_camf_c10_guicance_library_for_second_ellipse import *
 from .qzss_dcx_camf_ex1_target_area_code import *
 from .qzss_dcx_camf_ex9_target_area_code import *
 from .ublox_qzss_dcr_message_header import *
+from .ublox_qzss_svn_prn_map import *

--- a/azarashi/qzss_dcr_lib/definition/ublox_qzss_svn_prn_map.py
+++ b/azarashi/qzss_dcr_lib/definition/ublox_qzss_svn_prn_map.py
@@ -1,0 +1,6 @@
+ublox_qzss_svn_prn_map: dict[int, int] = {
+    2: 184,
+    3: 189,
+    4: 185,
+    5: 186,
+}


### PR DESCRIPTION
#17 の問題を修正しました。
SVIDとPRNの辞書を作成し、PRNの下位6 bitをSatellite IDとして用います。
また、Satellite IDのデフォルト値を仕様内に変更しました。
なお、本変更後に、MAX-M10Sで動作を確認しています。
